### PR TITLE
Tweak warning options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,11 @@ SET(ProjectName cpp-blocks)
 
 PROJECT(${ProjectName})
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+if(MSCV)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W3")
+else()
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+endif()
 
 SET(SourceFolder src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(ProjectName cpp-blocks)
 
 PROJECT(${ProjectName})
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W3")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 SET(SourceFolder src)
 

--- a/src/figure.hpp
+++ b/src/figure.hpp
@@ -25,7 +25,7 @@ class Figure {
     static bool collides_with_grid(const std::map<XY, Texture*>& grid, const Rect test_rect);
 public:
     FigureVariant variant;
-    char rotation;
+    unsigned char rotation;
     std::vector<Rect> squares;
 
     Figure(const std::vector<FigureVariant>& figure_variants);


### PR DESCRIPTION
Turned the `-W3` option to `-Wall`. The `-W3` is Visual C++ specific option and didn't work for me on Ubuntu. `-Wall` seemed to be supported by both compilers. This resulted in an extra warning during the compilation about signed and unsigned comparison. Got rid of this by making rotation an unsigned char.