### PR TITLE
Use runtime_error instead of exception

### DIFF
--- a/src/figure_variant.cpp
+++ b/src/figure_variant.cpp
@@ -6,7 +6,7 @@ using SDL2pp::Texture;
 
 std::vector<FigureVariant> create_variants(std::vector<SDL2pp::Texture*> textures) {
     if (textures.size() < 6) {
-        throw std::exception("At least six textures must be loaded");
+        throw std::runtime_error("At least six textures must be loaded");
     }
 
     vector<FigureVariant> figures;


### PR DESCRIPTION
The `std::exception(const char*)` constructor is not part of the C++ standard. Changed this to use `std::runtime_error` instead. The runtime error has a constructor that takes an error message as an argument.